### PR TITLE
add access control

### DIFF
--- a/test/Claims.constants.ts
+++ b/test/Claims.constants.ts
@@ -1,0 +1,14 @@
+import { Deploy } from "./src/Deploy";
+import { expect } from "chai";
+import { loadFixture } from "@nomicfoundation/hardhat-toolbox/network-helpers";
+import { Role } from "./src/Role";
+
+describe("Claims", function () {
+  describe("constants", function () {
+    it("should expose BOT_ROLE encoded hash", async function () {
+      const { Claims } = await loadFixture(Deploy);
+
+      expect(await Claims.BOT_ROLE()).to.equal(Role("BOT_ROLE"));
+    });
+  });
+});

--- a/test/Claims.createResolve.grantRole.ts
+++ b/test/Claims.createResolve.grantRole.ts
@@ -25,7 +25,16 @@ describe("Claims", function () {
         }
 
         {
-          expect(await Claims.hasRole(Role("BOT_ROLE"), Address(7))).to.equal(true);
+          expect(await Claims.hasRole(Role("BOT_ROLE"), Address(7))).to.equal(true); // granted
+          expect(await Claims.hasRole(Role("BOT_ROLE"), Address(9))).to.equal(false);
+        }
+
+        {
+          await Claims.connect(Signer(0)).revokeRole(Role("BOT_ROLE"), Address(7));
+        }
+
+        {
+          expect(await Claims.hasRole(Role("BOT_ROLE"), Address(7))).to.equal(false);
           expect(await Claims.hasRole(Role("BOT_ROLE"), Address(9))).to.equal(false);
         }
       });
@@ -40,6 +49,15 @@ describe("Claims", function () {
 
         {
           await Claims.connect(Signer(0)).grantRole(Role("NOT_ROLE"), Address(7));
+        }
+
+        {
+          expect(await Claims.hasRole(Role("BOT_ROLE"), Address(7))).to.equal(false);
+          expect(await Claims.hasRole(Role("BOT_ROLE"), Address(9))).to.equal(false);
+        }
+
+        {
+          await Claims.connect(Signer(0)).revokeRole(Role("NOT_ROLE"), Address(7));
         }
 
         {

--- a/test/Claims.createResolve.grantRole.ts
+++ b/test/Claims.createResolve.grantRole.ts
@@ -1,0 +1,52 @@
+import { Deploy } from "./src/Deploy";
+import { expect } from "chai";
+import { loadFixture } from "@nomicfoundation/hardhat-toolbox/network-helpers";
+import { Role } from "./src/Role";
+
+describe("Claims", function () {
+  describe("createResolve", function () {
+    describe("grantRole", function () {
+      const createPropose = async () => {
+        const { Address, Claims, Signer } = await loadFixture(Deploy);
+
+        return { Address, Claims, Signer };
+      }
+
+      it("should grant roles using the right role", async function () {
+        const { Address, Claims, Signer } = await loadFixture(createPropose);
+
+        {
+          expect(await Claims.hasRole(Role("BOT_ROLE"), Address(7))).to.equal(false);
+          expect(await Claims.hasRole(Role("BOT_ROLE"), Address(9))).to.equal(false);
+        }
+
+        {
+          await Claims.connect(Signer(0)).grantRole(Role("BOT_ROLE"), Address(7));
+        }
+
+        {
+          expect(await Claims.hasRole(Role("BOT_ROLE"), Address(7))).to.equal(true);
+          expect(await Claims.hasRole(Role("BOT_ROLE"), Address(9))).to.equal(false);
+        }
+      });
+
+      it("should not grant roles using the wrong role", async function () {
+        const { Address, Claims, Signer } = await loadFixture(createPropose);
+
+        {
+          expect(await Claims.hasRole(Role("BOT_ROLE"), Address(7))).to.equal(false);
+          expect(await Claims.hasRole(Role("BOT_ROLE"), Address(9))).to.equal(false);
+        }
+
+        {
+          await Claims.connect(Signer(0)).grantRole(Role("NOT_ROLE"), Address(7));
+        }
+
+        {
+          expect(await Claims.hasRole(Role("BOT_ROLE"), Address(7))).to.equal(false);
+          expect(await Claims.hasRole(Role("BOT_ROLE"), Address(9))).to.equal(false);
+        }
+      });
+    });
+  });
+});

--- a/test/Claims.createResolve.ts
+++ b/test/Claims.createResolve.ts
@@ -6,6 +6,7 @@ import { Expiry } from "./src/Expiry";
 import { Index } from "./src/Index";
 import { loadFixture } from "@nomicfoundation/hardhat-toolbox/network-helpers";
 import { network } from "hardhat";
+import { Role } from "./src/Role";
 import { Side } from "./src/Side";
 
 describe("Claims", function () {
@@ -55,6 +56,8 @@ describe("Claims", function () {
     it("signer 7 can create claim with lifecycle phase resolve", async function () {
       const { Address, Claims, Signer } = await loadFixture(createPropose);
 
+      await Claims.connect(Signer(0)).grantRole(Role("BOT_ROLE"), Address(7));
+
       await Claims.connect(Signer(7)).createResolve(
         Claim(1),
         Claim(7),
@@ -68,6 +71,8 @@ describe("Claims", function () {
 
     it("signer 9 can create claim with lifecycle phase resolve", async function () {
       const { Address, Claims, Signer } = await loadFixture(createPropose);
+
+      await Claims.connect(Signer(0)).grantRole(Role("BOT_ROLE"), Address(9));
 
       await Claims.connect(Signer(9)).createResolve(
         Claim(1),

--- a/test/Claims.updateResolve.revert.ts
+++ b/test/Claims.updateResolve.revert.ts
@@ -6,6 +6,7 @@ import { Expiry } from "./src/Expiry";
 import { Index } from "./src/Index";
 import { loadFixture } from "@nomicfoundation/hardhat-toolbox/network-helpers";
 import { network } from "hardhat";
+import { Role } from "./src/Role";
 import { Side } from "./src/Side";
 
 describe("Claims", function () {
@@ -49,6 +50,8 @@ describe("Claims", function () {
 
         await network.provider.send("evm_setNextBlockTimestamp", [Expiry(3, "days")]);
         await network.provider.send("evm_mine");
+
+        await Claims.connect(Signer(0)).grantRole(Role("BOT_ROLE"), Address(7));
 
         await Claims.connect(Signer(7)).createResolve(
           Claim(1),

--- a/test/Claims.updateResolve.ts
+++ b/test/Claims.updateResolve.ts
@@ -6,6 +6,7 @@ import { Expiry } from "./src/Expiry";
 import { Index } from "./src/Index";
 import { loadFixture } from "@nomicfoundation/hardhat-toolbox/network-helpers";
 import { network } from "hardhat";
+import { Role } from "./src/Role";
 import { Side } from "./src/Side";
 
 describe("Claims", function () {
@@ -48,6 +49,8 @@ describe("Claims", function () {
 
       await network.provider.send("evm_setNextBlockTimestamp", [Expiry(3, "days")]);
       await network.provider.send("evm_mine");
+
+      await Claims.connect(Signer(0)).grantRole(Role("BOT_ROLE"), Address(7));
 
       await Claims.connect(Signer(7)).createResolve(
         Claim(1),

--- a/test/src/Role.ts
+++ b/test/src/Role.ts
@@ -1,0 +1,7 @@
+import { Hex } from "viem";
+import { keccak256 } from "viem";
+import { stringToBytes } from "viem";
+
+export const Role = (rol: string): Hex => {
+  return keccak256(stringToBytes(rol));
+};


### PR DESCRIPTION
I was a bit too quick in #8 when I removed all access control. What I just realized is that anyone may call `updateBalance`, even though we will do it for the users with a bot. But then calling `createResolve` must be restricted to some trusted party for the time being, because here we decide who get's to vote by selecting random indices. There is no easy and gas efficient way to determine whether a computation was actually random at the time of writing. So we control the random truth sampling process offchain.