### PR TITLE
emit BalanceUpdated on every call to updateBalance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ node_modules
 # Hardhat files
 /cache
 /artifacts
-/ignition
+/ignition/deployments
 /storageLayout
 
 # TypeChain files

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ node_modules
 # Hardhat files
 /cache
 /artifacts
+/ignition
+/storageLayout
 
 # TypeChain files
 /typechain
@@ -13,6 +15,3 @@ node_modules
 # solidity-coverage files
 /coverage
 /coverage.json
-
-# Hardhat Ignition default folder for deployments against a local node
-ignition/deployments/chain-31337

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # contracts
 
+This repository contains the smart contracts of the Uvio platform. Learn more
+about Uvio at https://docs.uvio.network.
+
+
+
 ### formatting
 
 The smart contracts are formatted using `forge`. Details are configured in the

--- a/README.md
+++ b/README.md
@@ -10,6 +10,36 @@ more information.
 
 ### testing
 
+For local testing it is recommended to run an anvil node.
+
+```
+anvil --chain-id 1337
+```
+
+Deploy the smart contracts for local testing in order.
+
+```
+npx hardhat ignition deploy ./ignition/modules/Stablecoin.ts --network localhost
+npx hardhat ignition deploy ./ignition/modules/UVX.ts --network localhost
+npx hardhat ignition deploy ./ignition/modules/Claims.ts --network localhost
+```
+
+If the addresses deployed come out as shown below the setup should be alright.
+
+```
+Stablecoin    0x5FbDB2315678afecb367f032d93F642f64180aa3
+UVX           0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512
+Claims        0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0
+```
+
+Finally grant all necessary roles for the local setup to work properly.
+
+```
+npx hardhat run ./scripts/grantRoles.ts --network localhost
+```
+
+The accounts below are being used in the unit tests.
+
 ```
 Address(0) 0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266
 Address(1) 0x70997970C51812dc3A010C7d01b50e0d17dc79C8

--- a/README.md
+++ b/README.md
@@ -52,3 +52,40 @@ Address(7) 0x14dC79964da2C08b23698B3D3cc7Ca32193d9955
 Address(8) 0x23618e81E3f5cdF7f54C3d65f7FBc0aBf5B21E8f
 Address(9) 0xa0Ee7A142d267C1f36714E4a8F75612F20a79720
 ```
+
+The npm script `npm run cover` has been removed since the coverage report for
+this repository created more problems than it helped to solve. For one the
+coverage takes a relatively long time to wait for in CI. And then, a lot of our
+unit tests are time based. And for some reason the tests run using coverage
+enabled produce a lot of time glitches, which causes the tests to fail due to
+leap seconds. Long story short, we do not create code coverage reports in CI. If
+anyone wants to see those reports for themselves, just run the following
+command locally.
+
+```
+./node_modules/.bin/hardhat coverage
+```
+
+```
+----------------------|----------|----------|----------|----------|----------------|
+File                  |  % Stmts | % Branch |  % Funcs |  % Lines |Uncovered Lines |
+----------------------|----------|----------|----------|----------|----------------|
+ contracts/           |    99.31 |    89.68 |      100 |    95.41 |                |
+  Claims.sol          |    99.15 |    89.57 |      100 |    95.51 |... 3,1216,1516 |
+  UVX.sol             |      100 |       90 |      100 |    94.96 |... 320,332,370 |
+ contracts/interface/ |      100 |      100 |      100 |      100 |                |
+  ILender.sol         |      100 |      100 |      100 |      100 |                |
+  IReceiver.sol       |      100 |      100 |      100 |      100 |                |
+  IStablecoin.sol     |      100 |      100 |      100 |      100 |                |
+  IToken.sol          |      100 |      100 |      100 |      100 |                |
+ contracts/lib/       |      100 |      100 |      100 |      100 |                |
+  Bits.sol            |      100 |      100 |      100 |      100 |                |
+ contracts/mock/      |     87.5 |     37.5 |      100 |       75 |                |
+  Receiver.sol        |    83.33 |    33.33 |      100 |    71.43 |... 81,82,85,86 |
+  Stablecoin.sol      |      100 |       50 |      100 |    85.71 |             13 |
+ contracts/test/      |      100 |      100 |      100 |      100 |                |
+  BitsTest.sol        |      100 |      100 |      100 |      100 |                |
+----------------------|----------|----------|----------|----------|----------------|
+All files             |    98.71 |    88.36 |      100 |    94.62 |                |
+----------------------|----------|----------|----------|----------|----------------|
+```

--- a/contracts/Claims.sol
+++ b/contracts/Claims.sol
@@ -45,6 +45,14 @@ contract Claims is AccessControlEnumerable {
     // EVENTS
     //
 
+    // BalanceUpdated is emitted when user balances have been updated, whether
+    // for a propose or dispute, and whether the original propose has been
+    // settled onchain or not.
+    //
+    //     pod is the propose or dispute for which user balances got updated
+    //
+    event BalanceUpdated(uint256 pod);
+
     // ClaimUpdated is emitted when a claim is updated, whether it is a propose
     // or dispute.
     //
@@ -53,6 +61,7 @@ contract Claims is AccessControlEnumerable {
     //     bal is the amount of reputation aditionally staked
     //
     event ClaimUpdated(uint256 cla, address use, uint256 bal);
+
     // DisputeCreated is emitted when a dispute is created.
     //
     //     dis is the ID of the dispute that got created
@@ -61,6 +70,7 @@ contract Claims is AccessControlEnumerable {
     //     exp is the expiry of the new dispute
     //
     event DisputeCreated(uint256 dis, address use, uint256 bal, uint64 exp);
+
     // DisputeSettled is emitted when a dispute is settled. Once a dispute is
     // settled all user balances are updated, which makes the consensus reached
     // definitive and binding. For the final dispute in a tree of claims that
@@ -73,6 +83,7 @@ contract Claims is AccessControlEnumerable {
     //     tot is the amount of staked reputation being distributed
     //
     event DisputeSettled(uint256 dis, uint256 all, uint256 yay, uint256 nah, uint256 tot);
+
     // ProposeCreated is emitted when a propose is created.
     //
     //     pro is the ID of the propose that got created
@@ -81,6 +92,7 @@ contract Claims is AccessControlEnumerable {
     //     exp is the expiry of the new propose
     //
     event ProposeCreated(uint256 pro, address use, uint256 bal, uint64 exp);
+
     // ProposeSettled is emitted when a propose is settled. Once a propose is
     // settled all user balances are updated, which makes the consensus reached
     // definitive and binding.
@@ -92,6 +104,7 @@ contract Claims is AccessControlEnumerable {
     //     tot is the amount of staked reputation being distributed
     //
     event ProposeSettled(uint256 pro, uint256 all, uint256 yay, uint256 nah, uint256 tot);
+
     // ResolveCreated is emitted when a resolve is created.
     //
     //     pro is the ID of the propose for which the resolve got created
@@ -195,7 +208,7 @@ contract Claims is AccessControlEnumerable {
     uint256 public constant MID_UINT256 = type(uint256).max / 2;
 
     // VERSION is the code release of https://github.com/uvio-network/contracts.
-    string public constant VERSION = "v0.3.0";
+    string public constant VERSION = "v0.3.1";
 
     // VOTE_STAKE_Y is a bitmap index within _addressVotes. This boolean tracks
     // users who expressed their opinions by staking in agreement with the
@@ -1137,6 +1150,10 @@ contract Claims is AccessControlEnumerable {
             {
                 lef += dis + 1;
             }
+        }
+
+        {
+            emit BalanceUpdated(cla);
         }
 
         uint256 toy = _stakePropose[cla][CLAIM_STAKE_Y];

--- a/contracts/UVX.sol
+++ b/contracts/UVX.sol
@@ -53,7 +53,7 @@ contract UVX is AccessControlEnumerable, ERC20, ReentrancyGuard {
     bytes32 public constant TOKEN_ROLE = keccak256("TOKEN_ROLE");
 
     // VERSION is the code release of https://github.com/uvio-network/contracts.
-    string public constant VERSION = "v0.3.0";
+    string public constant VERSION = "v0.3.1";
 
     //
     // MAPPINGS

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,13 +12,13 @@
         "@openzeppelin/contracts": "^5.0.2"
       },
       "devDependencies": {
-        "@nomicfoundation/hardhat-chai-matchers": "^2.0.7",
+        "@nomicfoundation/hardhat-chai-matchers": "^2.0.8",
         "@nomicfoundation/hardhat-toolbox": "^5.0.0",
-        "@nomicfoundation/hardhat-verify": "^2.0.10",
-        "hardhat": "^2.22.9",
+        "@nomicfoundation/hardhat-verify": "^2.0.11",
+        "hardhat": "^2.22.11",
         "hardhat-storage-layout": "^0.1.7",
         "moment": "^2.30.1",
-        "viem": "^2.19.8"
+        "viem": "^2.21.12"
       }
     },
     "node_modules/@adraffy/ens-normalize": {
@@ -1156,9 +1156,9 @@
       }
     },
     "node_modules/@nomicfoundation/hardhat-chai-matchers": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-chai-matchers/-/hardhat-chai-matchers-2.0.7.tgz",
-      "integrity": "sha512-RQfsiTwdf0SP+DtuNYvm4921X6VirCQq0Xyh+mnuGlTwEFSPZ/o27oQC+l+3Y/l48DDU7+ZcYBR+Fp+Rp94LfQ==",
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-chai-matchers/-/hardhat-chai-matchers-2.0.8.tgz",
+      "integrity": "sha512-Z5PiCXH4xhNLASROlSUOADfhfpfhYO6D7Hn9xp8PddmHey0jq704cr6kfU8TRrQ4PUZbpfsZadPj+pCfZdjPIg==",
       "dev": true,
       "dependencies": {
         "@types/chai-as-promised": "^7.1.3",
@@ -1261,9 +1261,9 @@
       }
     },
     "node_modules/@nomicfoundation/hardhat-verify": {
-      "version": "2.0.10",
-      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-verify/-/hardhat-verify-2.0.10.tgz",
-      "integrity": "sha512-3zoTZGQhpeOm6piJDdsGb6euzZAd7N5Tk0zPQvGnfKQ0+AoxKz/7i4if12goi8IDTuUGElAUuZyQB8PMQoXA5g==",
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@nomicfoundation/hardhat-verify/-/hardhat-verify-2.0.11.tgz",
+      "integrity": "sha512-lGIo4dNjVQFdsiEgZp3KP6ntLiF7xJEJsbNHfSyIiFCyI0Yv0518ElsFtMC5uCuHEChiBBMrib9jWQvHHT+X3Q==",
       "dev": true,
       "dependencies": {
         "@ethersproject/abi": "^5.1.2",
@@ -1507,9 +1507,9 @@
       "integrity": "sha512-ytPc6eLGcHHnapAZ9S+5qsdomhjo6QBHTDRRBFfTxXIpsicMhVPouPgmUPebZZZGX7vt9USA+Z+0M0dSVtSUEA=="
     },
     "node_modules/@scure/base": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.7.tgz",
-      "integrity": "sha512-PPNYBslrLNNUQ/Yad37MHYsNQtK67EhWb6WtSvNLLPo7SdVZgkUjD6Dg+5On7zNwmskf8OX7I7Nx5oN+MIWE0g==",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.9.tgz",
+      "integrity": "sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg==",
       "dev": true,
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -1558,6 +1558,7 @@
       "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.3.0.tgz",
       "integrity": "sha512-disdg7gHuTDZtY+ZdkmLpPCk7fxZSu3gBiEGuoC1XYxv9cGx3Z6cpTggCgW6odSOOIXCiDjuGejW+aJKCY/pIQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@noble/hashes": "~1.4.0",
         "@scure/base": "~1.1.6"
@@ -1571,6 +1572,7 @@
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
       "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">= 16"
       },
@@ -4027,9 +4029,9 @@
       }
     },
     "node_modules/hardhat": {
-      "version": "2.22.9",
-      "resolved": "https://registry.npmjs.org/hardhat/-/hardhat-2.22.9.tgz",
-      "integrity": "sha512-sWiuI/yRdFUPfndIvL+2H18Vs2Gav0XacCFYY5msT5dHOWkhLxESJySIk9j83mXL31aXL8+UMA9OgViFLexklg==",
+      "version": "2.22.11",
+      "resolved": "https://registry.npmjs.org/hardhat/-/hardhat-2.22.11.tgz",
+      "integrity": "sha512-g9xr6BGXbzj2sqG9AjHwqeUOS9v2NwLbuq7rsdjMB2RLWmYp8IFdZnzq8UewwLJisuWgiygB+dwLktjqAbRuOw==",
       "dev": true,
       "dependencies": {
         "@ethersproject/abi": "^5.1.2",
@@ -4047,7 +4049,7 @@
         "ansi-escapes": "^4.3.0",
         "boxen": "^5.1.2",
         "chalk": "^2.4.2",
-        "chokidar": "^3.4.0",
+        "chokidar": "^4.0.0",
         "ci-info": "^2.0.0",
         "debug": "^4.1.1",
         "enquirer": "^2.3.0",
@@ -4060,6 +4062,7 @@
         "glob": "7.2.0",
         "immutable": "^4.0.0-rc.12",
         "io-ts": "1.10.4",
+        "json-stream-stringify": "^3.1.4",
         "keccak": "^3.0.2",
         "lodash": "^4.17.11",
         "mnemonist": "^0.38.0",
@@ -4190,6 +4193,21 @@
         "node": ">=4"
       }
     },
+    "node_modules/hardhat/node_modules/chokidar": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.1.tgz",
+      "integrity": "sha512-n8enUVCED/KVRQlab1hr3MVpcVMvxtZjmEa956u+4YijlmQED223XMSYj2tLuKvr4jcCTzNNMpQDUer72MMmzA==",
+      "dev": true,
+      "dependencies": {
+        "readdirp": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/hardhat/node_modules/color-convert": {
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -4256,6 +4274,19 @@
       "dev": true,
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
+      }
+    },
+    "node_modules/hardhat/node_modules/readdirp": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.0.1.tgz",
+      "integrity": "sha512-GkMg9uOTpIWWKbSsgwb5fA4EavTR+SG/PMPoAY8hkhHfEEY0/vqljY+XHqtDf2cr2IJtoNRDbrrEpZUiZCkYRw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14.16.0"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/hardhat/node_modules/supports-color": {
@@ -4699,6 +4730,15 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
       "dev": true
+    },
+    "node_modules/json-stream-stringify": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/json-stream-stringify/-/json-stream-stringify-3.1.4.tgz",
+      "integrity": "sha512-oGoz05ft577LolnXFQHD2CjnXDxXVA5b8lHwfEZgRXQUZeCMo6sObQQRq+NXuHQ3oTeMZHHmmPY2rjVwyqR62A==",
+      "dev": true,
+      "engines": {
+        "node": ">=7.10.1"
+      }
     },
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
@@ -6985,9 +7025,9 @@
       "peer": true
     },
     "node_modules/viem": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/viem/-/viem-2.20.0.tgz",
-      "integrity": "sha512-cM4vs81HnSNbfceI1MLkx4pCVzbVjl9xiNSv5SCutYjUyFFOVSPDlEyhpg2iHinxx1NM4Qne3END5eLT8rvUdg==",
+      "version": "2.21.12",
+      "resolved": "https://registry.npmjs.org/viem/-/viem-2.21.12.tgz",
+      "integrity": "sha512-yPZulbPdoDnuB8Gm2m+Qc9Mjgl6gC1YgNU6zcO+C8XZNYwaCNE6mokPiy30m8o5I1XkfvMc35jMmtT1zCb8yxA==",
       "dev": true,
       "funding": [
         {
@@ -7000,7 +7040,7 @@
         "@noble/curves": "1.4.0",
         "@noble/hashes": "1.4.0",
         "@scure/bip32": "1.4.0",
-        "@scure/bip39": "1.3.0",
+        "@scure/bip39": "1.4.0",
         "abitype": "1.0.5",
         "isows": "1.0.4",
         "webauthn-p256": "0.0.5",
@@ -7040,6 +7080,31 @@
       "dev": true,
       "engines": {
         "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/viem/node_modules/@scure/bip39": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.4.0.tgz",
+      "integrity": "sha512-BEEm6p8IueV/ZTfQLp/0vhw4NPnT9oWf5+28nvmeUICjP99f4vr2d+qc7AVGDDtwRep6ifR43Yed9ERVmiITzw==",
+      "dev": true,
+      "dependencies": {
+        "@noble/hashes": "~1.5.0",
+        "@scure/base": "~1.1.8"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/viem/node_modules/@scure/bip39/node_modules/@noble/hashes": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.5.0.tgz",
+      "integrity": "sha512-1j6kQFb7QRru7eKN3ZDvRcP13rugwdxZqCjbiAVZfIJwgj2A65UmT4TgARXGlXgnRkORLTDTrO19ZErt7+QXgA==",
+      "dev": true,
+      "engines": {
+        "node": "^14.21.3 || >=16"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "contracts",
-  "version": "v0.0.1",
+  "version": "v0.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "contracts",
-      "version": "v0.0.1",
+      "version": "v0.3.1",
       "license": "MIT",
       "dependencies": {
         "@openzeppelin/contracts": "^5.0.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "contracts",
-  "version": "v0.0.1",
+  "version": "v0.3.1",
   "description": "smart contracts of the Uvio platform",
   "scripts": {
     "compile": "./node_modules/.bin/hardhat compile",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "scripts": {
     "compile": "./node_modules/.bin/hardhat compile",
     "clean": "./node_modules/.bin/hardhat clean",
-    "cover": "./node_modules/.bin/hardhat coverage",
     "test": "./node_modules/.bin/hardhat test"
   },
   "repository": {
@@ -19,13 +18,13 @@
   },
   "homepage": "https://github.com/uvio-network/contracts#readme",
   "devDependencies": {
-    "@nomicfoundation/hardhat-chai-matchers": "^2.0.7",
+    "@nomicfoundation/hardhat-chai-matchers": "^2.0.8",
     "@nomicfoundation/hardhat-toolbox": "^5.0.0",
-    "@nomicfoundation/hardhat-verify": "^2.0.10",
-    "hardhat": "^2.22.9",
+    "@nomicfoundation/hardhat-verify": "^2.0.11",
+    "hardhat": "^2.22.11",
     "hardhat-storage-layout": "^0.1.7",
     "moment": "^2.30.1",
-    "viem": "^2.19.8"
+    "viem": "^2.21.12"
   },
   "dependencies": {
     "@openzeppelin/contracts": "^5.0.2"

--- a/scripts/grantRoles.ts
+++ b/scripts/grantRoles.ts
@@ -1,0 +1,33 @@
+import { ethers } from "hardhat";
+import { Role } from "../test/src/Role";
+
+// DEPLOYER_PRIVATE_KEY is well known the Hardhat/Anvil deployer.
+const DEPLOYER_PRIVATE_KEY = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
+
+//
+//     npx hardhat run ./scripts/grantRoles.ts --network localhost
+//
+const main = async () => {
+  const Claims = await ethers.getContractAt("Claims", "0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0");
+  const UVX = await ethers.getContractAt("UVX", "0xe7f1725E7734CE288F8367e1Bb143E90bb3F0512");
+
+  const wal = new ethers.Wallet(DEPLOYER_PRIVATE_KEY, ethers.provider);
+
+  try {
+    // Allow the deployer to resolve claims.
+    await Claims.connect(wal).grantRole(Role("BOT_ROLE"), "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
+
+    // Allow the deployer to mint UVX tokens.
+    await UVX.connect(wal).grantRole(Role("BOT_ROLE"), "0xf39Fd6e51aad88F6F4ce6aB8827279cffFb92266");
+
+    // Allow UVX tokens to be transferred across the Claims contract.
+    await UVX.connect(wal).grantRole(Role("CONTRACT_ROLE"), "0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0");
+  } catch (error) {
+    console.error("Error:", error);
+  }
+};
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/scripts/updateExpiry.ts
+++ b/scripts/updateExpiry.ts
@@ -1,21 +1,23 @@
 import { ethers } from "hardhat";
 
+// DEPLOYER_PRIVATE_KEY is well known the Hardhat/Anvil deployer.
+const DEPLOYER_PRIVATE_KEY = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
+
 //
 //     npx hardhat run ./scripts/updateExpiry.ts --network localhost
 //
 const main = async () => {
   const Claims = await ethers.getContractAt("Claims", "0x9fE46736679d2D9a65F0992F2272dE9f3c7fa6e0");
 
-  const DEPLOYER_PRIVATE_KEY = "0xac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
   const wal = new ethers.Wallet(DEPLOYER_PRIVATE_KEY, ethers.provider);
-  const pro = 1726738606883291;
-  const exp = 1726738980;
+  const pro = 1726927374511731;
+  const exp = 1726927560;
 
   try {
     const bef = await Claims.connect(wal).searchExpired(pro);
     console.log("bef", bef)
 
-    // await Claims.connect(wal).updateExpiry(pro, exp);
+    await Claims.connect(wal).updateExpiry(pro, exp);
 
     const aft = await Claims.connect(wal).searchExpired(pro);
     console.log("aft", aft)

--- a/test/Claims.constants.ts
+++ b/test/Claims.constants.ts
@@ -32,7 +32,7 @@ describe("Claims", function () {
     it("should expose VERSION constant", async function () {
       const { Claims } = await loadFixture(Deploy);
 
-      expect(await Claims.VERSION()).to.equal("v0.3.0");
+      expect(await Claims.VERSION()).to.equal("v0.3.1");
     });
   });
 });

--- a/test/Claims.updateBalance.dispute.ts
+++ b/test/Claims.updateBalance.dispute.ts
@@ -372,6 +372,12 @@ describe("Claims", function () {
         it("should emit event", async function () {
           const { Claims, tx1, tx2, tx3 } = await loadFixture(UpdateBalanceMaxDispute);
 
+          // Here we do also test that the event BalanceUpdated is emitted on
+          // each call to updateBalance.
+          await expect(tx1).to.emit(Claims, "BalanceUpdated").withArgs(Claim(101));
+          await expect(tx2).to.emit(Claims, "BalanceUpdated").withArgs(Claim(1));
+          await expect(tx3).to.emit(Claims, "BalanceUpdated").withArgs(Claim(102));
+
           // Here we do also test that the order of updating balances within a
           // tree of disputed claims does not matter. The final consensus is
           // applied throughout the tree.

--- a/test/Claims.updateBalance.multiple.ts
+++ b/test/Claims.updateBalance.multiple.ts
@@ -211,7 +211,7 @@ describe("Claims", function () {
           await Balance([1, 2, 3, 4, 5, 6, 7, 8], 50);
 
           await Claims.connect(Signer(1)).createPropose(
-            Claim(1),
+            Claim(23),
             Amount(10),
             Side(true),
             EXPIRY,
@@ -219,50 +219,50 @@ describe("Claims", function () {
             [],
           );
           await Claims.connect(Signer(2)).updatePropose(
-            Claim(1),
+            Claim(23),
             Amount(20),
             Side(true),
             0,
           );
           await Claims.connect(Signer(3)).updatePropose(
-            Claim(1),
+            Claim(23),
             Amount(30),
             Side(true),
             0,
           );
           await Claims.connect(Signer(1)).updatePropose(
-            Claim(1),
+            Claim(23),
             Amount(10),
             Side(true),
             0,
           );
 
           await Claims.connect(Signer(4)).updatePropose(
-            Claim(1),
+            Claim(23),
             Amount(25),
             Side(false),
             0,
           );
           await Claims.connect(Signer(5)).updatePropose(
-            Claim(1),
+            Claim(23),
             Amount(30),
             Side(false),
             0,
           );
           await Claims.connect(Signer(6)).updatePropose(
-            Claim(1),
+            Claim(23),
             Amount(30),
             Side(false),
             0,
           );
           await Claims.connect(Signer(7)).updatePropose(
-            Claim(1),
+            Claim(23),
             Amount(20),
             Side(false),
             0,
           );
           await Claims.connect(Signer(8)).updatePropose(
-            Claim(1),
+            Claim(23),
             Amount(10),
             Side(false),
             0,
@@ -274,18 +274,18 @@ describe("Claims", function () {
           await Claims.connect(Signer(0)).grantRole(Role("BOT_ROLE"), Address(7));
 
           await Claims.connect(Signer(7)).createResolve(
-            Claim(1),
+            Claim(23),
             [0, MAX], // address 1 and 4
             Expiry(7, "days"),
           );
 
           await Claims.connect(Signer(1)).updateResolve(
-            Claim(1),
+            Claim(23),
             Side(true),
           );
 
           await Claims.connect(Signer(4)).updateResolve(
-            Claim(1),
+            Claim(23),
             Side(true),
           );
 
@@ -298,50 +298,50 @@ describe("Claims", function () {
           await network.provider.send("evm_setNextBlockTimestamp", [Expiry(14, "days")]); // 7 days + challenge
           await network.provider.send("evm_mine");
 
-          await Claims.connect(Signer(0)).updateBalance(
-            Claim(1),
+          const tx1 = await Claims.connect(Signer(0)).updateBalance(
+            Claim(23),
             3,
           );
 
-          expect(await Claims.searchResolve(Claim(1), await Claims.CLAIM_BALANCE_P())).to.equal(false);
-          expect(await Claims.searchResolve(Claim(1), await Claims.CLAIM_BALANCE_R())).to.equal(true);
-          expect(await Claims.searchResolve(Claim(1), await Claims.CLAIM_BALANCE_S())).to.equal(false);
+          expect(await Claims.searchResolve(Claim(23), await Claims.CLAIM_BALANCE_P())).to.equal(false);
+          expect(await Claims.searchResolve(Claim(23), await Claims.CLAIM_BALANCE_R())).to.equal(true);
+          expect(await Claims.searchResolve(Claim(23), await Claims.CLAIM_BALANCE_S())).to.equal(false);
 
-          await Claims.connect(Signer(0)).updateBalance(
-            Claim(1),
+          const tx2 = await Claims.connect(Signer(0)).updateBalance(
+            Claim(23),
             3,
           );
 
-          expect(await Claims.searchResolve(Claim(1), await Claims.CLAIM_BALANCE_P())).to.equal(false);
-          expect(await Claims.searchResolve(Claim(1), await Claims.CLAIM_BALANCE_R())).to.equal(true);
-          expect(await Claims.searchResolve(Claim(1), await Claims.CLAIM_BALANCE_S())).to.equal(false);
+          expect(await Claims.searchResolve(Claim(23), await Claims.CLAIM_BALANCE_P())).to.equal(false);
+          expect(await Claims.searchResolve(Claim(23), await Claims.CLAIM_BALANCE_R())).to.equal(true);
+          expect(await Claims.searchResolve(Claim(23), await Claims.CLAIM_BALANCE_S())).to.equal(false);
 
-          const txn = await Claims.connect(Signer(0)).updateBalance(
-            Claim(1),
+          const tx3 = await Claims.connect(Signer(0)).updateBalance(
+            Claim(23),
             8,
           );
 
-          return { Address, Claims, Signer, txn, UVX };
+          return { Address, Claims, Signer, tx1, tx2, tx3, UVX };
         }
 
         it("should record all votes", async function () {
           const { Claims } = await loadFixture(updateBalance);
 
-          expect(await Claims.searchVotes(Claim(1))).to.deep.equal([2, 0]);
+          expect(await Claims.searchVotes(Claim(23))).to.deep.equal([2, 0]);
         });
 
         it("should update balances by rewarding users", async function () {
           const { Claims } = await loadFixture(updateBalance);
 
-          expect(await Claims.searchResolve(Claim(1), await Claims.CLAIM_BALANCE_P())).to.equal(false);
-          expect(await Claims.searchResolve(Claim(1), await Claims.CLAIM_BALANCE_R())).to.equal(true);
-          expect(await Claims.searchResolve(Claim(1), await Claims.CLAIM_BALANCE_S())).to.equal(true);
+          expect(await Claims.searchResolve(Claim(23), await Claims.CLAIM_BALANCE_P())).to.equal(false);
+          expect(await Claims.searchResolve(Claim(23), await Claims.CLAIM_BALANCE_R())).to.equal(true);
+          expect(await Claims.searchResolve(Claim(23), await Claims.CLAIM_BALANCE_S())).to.equal(true);
         });
 
         it("should have 185 tokens staked", async function () {
           const { Claims } = await loadFixture(updateBalance);
 
-          const res = await Claims.searchPropose(Claim(1));
+          const res = await Claims.searchPropose(Claim(23));
 
           expect(res[0]).to.equal(Amount(70));  // yay
           expect(res[1]).to.equal(Amount(10));  // min
@@ -443,9 +443,13 @@ describe("Claims", function () {
         });
 
         it("should emit event", async function () {
-          const { Claims, txn } = await loadFixture(updateBalance);
+          const { Claims, tx1, tx2, tx3 } = await loadFixture(updateBalance);
 
-          await expect(txn).to.emit(Claims, "ProposeSettled").withArgs(Claim(1), 8, 2, 0, Amount(185));
+          await expect(tx1).to.emit(Claims, "BalanceUpdated").withArgs(Claim(23));
+          await expect(tx2).to.emit(Claims, "BalanceUpdated").withArgs(Claim(23));
+          await expect(tx3).to.emit(Claims, "BalanceUpdated").withArgs(Claim(23));
+
+          await expect(tx3).to.emit(Claims, "ProposeSettled").withArgs(Claim(23), 8, 2, 0, Amount(185));
         });
       });
     });

--- a/test/Claims.updateBalance.punish.ts
+++ b/test/Claims.updateBalance.punish.ts
@@ -493,9 +493,14 @@ describe("Claims", function () {
         });
 
         it("should emit event", async function () {
-          const { Claims, txn } = await loadFixture(UpdateBalancePunishEqualVotes);
+          const { Claims, tx1, tx2 } = await loadFixture(UpdateBalancePunishEqualVotes);
 
-          await expect(txn).to.emit(Claims, "ProposeSettled").withArgs(Claim(1), 5, 1, 1, Amount(118));
+          // Here we do also test that the event BalanceUpdated is emitted on
+          // each call to updateBalance.
+          await expect(tx1).to.emit(Claims, "BalanceUpdated").withArgs(Claim(1));
+          await expect(tx2).to.emit(Claims, "BalanceUpdated").withArgs(Claim(1));
+
+          await expect(tx2).to.emit(Claims, "ProposeSettled").withArgs(Claim(1), 5, 1, 1, Amount(118));
         });
       });
 

--- a/test/UVX.constants.ts
+++ b/test/UVX.constants.ts
@@ -32,7 +32,7 @@ describe("UVX", function () {
     it("should expose VERSION constant", async function () {
       const { UVX } = await loadFixture(Deploy);
 
-      expect(await UVX.VERSION()).to.equal("v0.3.0");
+      expect(await UVX.VERSION()).to.equal("v0.3.1");
     });
   });
 });

--- a/test/src/Deploy.ts
+++ b/test/src/Deploy.ts
@@ -751,17 +751,17 @@ export const UpdateBalancePunishEqualVotes = async () => {
   await network.provider.send("evm_setNextBlockTimestamp", [Expiry(14, "days")]); // 7 days + challenge
   await network.provider.send("evm_mine");
 
-  await Claims.connect(Signer(0)).updateBalance(
+  const tx1 = await Claims.connect(Signer(0)).updateBalance(
     Claim(1),
     3,
   );
 
-  const txn = await Claims.connect(Signer(0)).updateBalance(
+  const tx2 = await Claims.connect(Signer(0)).updateBalance(
     Claim(1),
     2,
   );
 
-  return { Address, Balance, Claims, Signer, txn, UVX };
+  return { Address, Balance, Claims, Signer, tx1, tx2, UVX };
 };
 
 export const UpdateBalanceBoth22True33False = async () => {


### PR DESCRIPTION
While working on https://github.com/uvio-network/issues/issues/30 I noticed that finalizing a claim sub-tree may require multiple calls to `updateBalance` if a large number of market participants have been staking. "Large" here means more than 100, which should hopefully be the case at some point.

So in order to automate and reconcile the claim state, settling a claim onchain may require multiple transactions for updating user balances. Those transaction hashes must be recoverable in our background processes, and filtering events is the only viable option I am aware of right now to find the transaction hash of some onchain action after the fact.

For this reason we simply emit `BalanceUpdated` with the ID of the propose or dispute being settled. This change extends the contract interface and we are bumping the version to `v0.3.1`.